### PR TITLE
GPT 일기 생성 Steam 방식 추가

### DIFF
--- a/src/docs/asciidoc/guide.adoc
+++ b/src/docs/asciidoc/guide.adoc
@@ -13,6 +13,23 @@ include::{snippets}/gpt/create/success/request-fields.adoc[]
 ==== 응답
 include::{snippets}/gpt/create/success/http-response.adoc[]
 
+
+=== GPT 일기 생성 - Stream
+GPT API를 통해 일기를 생성합니다.
+실시간 단방향 통신을 지원하며 SSE 방식을 통해 생성되는 일기 데이터를 클라이언트에게 chunk 단위로 전송합니다.
+
+실제 데이터는 data>choices>delta>content에 담기며 종료 상황이 발생한 경우 finish_reason에 종료 상황이 명시되고 연결이 종료됩니다.
+
+[discrete]
+==== 요청
+include::{snippets}/gpt/create-stream/success/http-request.adoc[]
+include::{snippets}/gpt/create-stream/success/request-fields.adoc[]
+
+[discrete]
+==== 응답
+include::{snippets}/gpt/create-stream/success/http-response.adoc[]
+
+
 === GPT 일기 가이드 조회
 GPT 일기 자동생성을 위한 일기 가이드를 조회합니다.
 

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -577,10 +577,11 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <li><a href="#_gpt_일기_가이드">4. GPT 일기 가이드</a>
 <ul class="sectlevel2">
 <li><a href="#_gpt_일기_생성">4.1. GPT 일기 생성</a></li>
-<li><a href="#_gpt_일기_가이드_조회">4.2. GPT 일기 가이드 조회</a></li>
-<li><a href="#_gpt_일기_가이드_디테일_조회">4.3. GPT 일기 가이드 디테일 조회</a></li>
-<li><a href="#_gpt_일기_가이드_디테일_생성">4.4. GPT 일기 가이드 디테일 생성</a></li>
-<li><a href="#_gpt_일기_가이드_디테일_삭제">4.5. GPT 일기 가이드 디테일 삭제</a></li>
+<li><a href="#_gpt_일기_생성_stream">4.2. GPT 일기 생성 - Stream</a></li>
+<li><a href="#_gpt_일기_가이드_조회">4.3. GPT 일기 가이드 조회</a></li>
+<li><a href="#_gpt_일기_가이드_디테일_조회">4.4. GPT 일기 가이드 디테일 조회</a></li>
+<li><a href="#_gpt_일기_가이드_디테일_생성">4.5. GPT 일기 가이드 디테일 생성</a></li>
+<li><a href="#_gpt_일기_가이드_디테일_삭제">4.6. GPT 일기 가이드 디테일 삭제</a></li>
 </ul>
 </li>
 <li><a href="#_일기">5. 일기</a>
@@ -1245,7 +1246,7 @@ Content-Length: 189
     &quot;id&quot; : 1,
     &quot;name&quot; : &quot;멈무유치원&quot;,
     &quot;email&quot; : &quot;meommu@exam.com&quot;,
-    &quot;createdAt&quot; : &quot;2023-11-28T14:19:24.013398&quot;
+    &quot;createdAt&quot; : &quot;2023-11-28T16:11:24.111569&quot;
   }
 }</code></pre>
 </div>
@@ -1354,7 +1355,7 @@ Content-Length: 189
     &quot;id&quot; : 1,
     &quot;name&quot; : &quot;멈무유치원&quot;,
     &quot;email&quot; : &quot;meommu@exam.com&quot;,
-    &quot;createdAt&quot; : &quot;2023-11-28T14:19:24.049164&quot;
+    &quot;createdAt&quot; : &quot;2023-11-28T16:11:24.144669&quot;
   }
 }</code></pre>
 </div>
@@ -2111,11 +2112,144 @@ Content-Length: 105
 </div>
 </div>
 <div class="sect2">
-<h3 id="_gpt_일기_가이드_조회"><a class="link" href="#_gpt_일기_가이드_조회">4.2. GPT 일기 가이드 조회</a></h3>
+<h3 id="_gpt_일기_생성_stream"><a class="link" href="#_gpt_일기_생성_stream">4.2. GPT 일기 생성 - Stream</a></h3>
+<div class="paragraph">
+<p>GPT API를 통해 일기를 생성합니다.
+실시간 단방향 통신을 지원하며 SSE 방식을 통해 생성되는 일기 데이터를 클라이언트에게 chunk 단위로 전송합니다.</p>
+</div>
+<div class="paragraph">
+<p>실제 데이터는 data&gt;choices&gt;delta&gt;content에 담기며 종료 상황이 발생한 경우 finish_reason에 종료 상황이 명시되고 연결이 종료됩니다.</p>
+</div>
+<h4 id="_요청_18" class="discrete">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/gpt/stream HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer &lt;ACCESS_TOKEN&gt;
+Content-Length: 76
+Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
+
+{
+  &quot;details&quot; : &quot;수영장에서 친구랑 놀기|맛있는 간식 먹기&quot;
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">제약사항</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>details</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">일기 생성을 위한 디테일</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">일기 디테일은 최소 1개이상 존재해야하며, 디테일들은 파이프(|)로 구분되어야 합니다.</p></td>
+</tr>
+</tbody>
+</table>
+<h4 id="_응답_18" class="discrete">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: text/event-stream;charset=UTF-8
+Content-Length: 1606
+
+data:    {
+        &quot;id&quot;: &quot;chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM&quot;,
+        &quot;object&quot;: &quot;chat.completion.chunk&quot;,
+        &quot;created&quot;: 1701149452,
+        &quot;model&quot;: &quot;gpt-3.5-turbo-0613&quot;,
+        &quot;choices&quot;: [
+            {
+                &quot;index&quot;: 0,
+                &quot;delta&quot;: {
+                    &quot;role&quot;: &quot;assistant&quot;,
+                    &quot;content&quot;: &quot;&quot;
+                },
+                &quot;finish_reason&quot;: null
+            }
+        ]
+    }
+
+
+data:    {
+        &quot;id&quot;: &quot;chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM&quot;,
+        &quot;object&quot;: &quot;chat.completion.chunk&quot;,
+        &quot;created&quot;: 1701149452,
+        &quot;model&quot;: &quot;gpt-3.5-turbo-0613&quot;,
+        &quot;choices&quot;: [
+            {
+                &quot;index&quot;: 0,
+                &quot;delta&quot;: {
+                    &quot;content&quot;: &quot;일&quot;
+                },
+                &quot;finish_reason&quot;: null
+            }
+        ]
+    }
+
+
+data:    {
+        &quot;id&quot;: &quot;chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM&quot;,
+        &quot;object&quot;: &quot;chat.completion.chunk&quot;,
+        &quot;created&quot;: 1701149452,
+        &quot;model&quot;: &quot;gpt-3.5-turbo-0613&quot;,
+        &quot;choices&quot;: [
+            {
+                &quot;index&quot;: 0,
+                &quot;delta&quot;: {
+                    &quot;content&quot;: &quot;기&quot;
+                },
+                &quot;finish_reason&quot;: null
+            }
+        ]
+    }
+
+
+data:    {
+        &quot;id&quot;: &quot;chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM&quot;,
+        &quot;object&quot;: &quot;chat.completion.chunk&quot;,
+        &quot;created&quot;: 1701149452,
+        &quot;model&quot;: &quot;gpt-3.5-turbo-0613&quot;,
+        &quot;choices&quot;: [
+            {
+                &quot;index&quot;: 0,
+                &quot;delta&quot;: {},
+                &quot;finish_reason&quot;: &quot;stop&quot;
+            }
+        ]
+    }
+
+
+data:    {
+        &quot;[DONE]&quot;
+    }</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_gpt_일기_가이드_조회"><a class="link" href="#_gpt_일기_가이드_조회">4.3. GPT 일기 가이드 조회</a></h3>
 <div class="paragraph">
 <p>GPT 일기 자동생성을 위한 일기 가이드를 조회합니다.</p>
 </div>
-<h4 id="_요청_18" class="discrete">요청</h4>
+<h4 id="_요청_19" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/guides HTTP/1.1
@@ -2123,7 +2257,7 @@ Authorization: Bearer &lt;ACCESS_TOKEN&gt;
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
-<h4 id="_응답_18" class="discrete">응답</h4>
+<h4 id="_응답_19" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2152,11 +2286,11 @@ Content-Length: 355
 </div>
 </div>
 <div class="sect2">
-<h3 id="_gpt_일기_가이드_디테일_조회"><a class="link" href="#_gpt_일기_가이드_디테일_조회">4.3. GPT 일기 가이드 디테일 조회</a></h3>
+<h3 id="_gpt_일기_가이드_디테일_조회"><a class="link" href="#_gpt_일기_가이드_디테일_조회">4.4. GPT 일기 가이드 디테일 조회</a></h3>
 <div class="paragraph">
 <p>GPT 일기 자동생성을 위한 일기 가이드 디테일을 조회합니다.</p>
 </div>
-<h4 id="_요청_19" class="discrete">요청</h4>
+<h4 id="_요청_20" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/guides/1/details HTTP/1.1
@@ -2183,7 +2317,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_19" class="discrete">응답</h4>
+<h4 id="_응답_20" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2210,11 +2344,11 @@ Content-Length: 226
 </div>
 </div>
 <div class="sect2">
-<h3 id="_gpt_일기_가이드_디테일_생성"><a class="link" href="#_gpt_일기_가이드_디테일_생성">4.4. GPT 일기 가이드 디테일 생성</a></h3>
+<h3 id="_gpt_일기_가이드_디테일_생성"><a class="link" href="#_gpt_일기_가이드_디테일_생성">4.5. GPT 일기 가이드 디테일 생성</a></h3>
 <div class="paragraph">
 <p>GPT 일기 자동생성을 위한 일기 가이드 디테일을 생성합니다.</p>
 </div>
-<h4 id="_요청_20" class="discrete">요청</h4>
+<h4 id="_요청_21" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/guides/1/details HTTP/1.1
@@ -2274,7 +2408,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_20" class="discrete">응답</h4>
+<h4 id="_응답_21" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2301,11 +2435,11 @@ Content-Length: 226
 </div>
 </div>
 <div class="sect2">
-<h3 id="_gpt_일기_가이드_디테일_삭제"><a class="link" href="#_gpt_일기_가이드_디테일_삭제">4.5. GPT 일기 가이드 디테일 삭제</a></h3>
+<h3 id="_gpt_일기_가이드_디테일_삭제"><a class="link" href="#_gpt_일기_가이드_디테일_삭제">4.6. GPT 일기 가이드 디테일 삭제</a></h3>
 <div class="paragraph">
 <p>GPT 일기 자동생성을 위한 일기 가이드 디테일을 삭제합니다.</p>
 </div>
-<h4 id="_요청_21" class="discrete">요청</h4>
+<h4 id="_요청_22" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/guides/1/details/1 HTTP/1.1
@@ -2336,7 +2470,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_21" class="discrete">응답</h4>
+<h4 id="_응답_22" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2368,7 +2502,7 @@ Content-Length: 62
 <p>일기 요약 정보를 조회합니다. 최신순으로 정렬됩니다.
 이미지 URL은 이미지 API를 통해 id로 조회하면 됩니다.</p>
 </div>
-<h4 id="_요청_22" class="discrete">요청</h4>
+<h4 id="_요청_23" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries/summary HTTP/1.1
@@ -2376,7 +2510,7 @@ Authorization: Bearer &lt;ACCESS_TOKEN&gt;
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
-<h4 id="_응답_22" class="discrete">응답</h4>
+<h4 id="_응답_23" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2393,12 +2527,12 @@ Content-Length: 364
     &quot;diaries&quot; : [ {
       &quot;id&quot; : 2,
       &quot;date&quot; : &quot;2023-11-28&quot;,
-      &quot;createdAt&quot; : &quot;2023-11-28T14:19:23.036399&quot;,
+      &quot;createdAt&quot; : &quot;2023-11-28T16:11:22.877273&quot;,
       &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ]
     }, {
       &quot;id&quot; : 1,
       &quot;date&quot; : &quot;2023-11-27&quot;,
-      &quot;createdAt&quot; : &quot;2023-11-28T14:19:23.036389&quot;,
+      &quot;createdAt&quot; : &quot;2023-11-28T16:11:22.877264&quot;,
       &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ]
     } ]
   }
@@ -2412,7 +2546,7 @@ Content-Length: 364
 <p>일기를 년월별로 조회합니다. 최신순으로 정렬됩니다.
 이미지 URL은 이미지 API를 통해 id로 조회하면 됩니다.</p>
 </div>
-<h4 id="_요청_23" class="discrete">요청</h4>
+<h4 id="_요청_24" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries?year=2023&amp;month=11 HTTP/1.1
@@ -2450,7 +2584,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_23" class="discrete">응답</h4>
+<h4 id="_응답_24" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2468,7 +2602,7 @@ Content-Length: 564
       &quot;id&quot; : 2,
       &quot;date&quot; : &quot;2023-11-28&quot;,
       &quot;dogName&quot; : &quot;똘이&quot;,
-      &quot;createdAt&quot; : &quot;2023-11-28T14:19:22.986689&quot;,
+      &quot;createdAt&quot; : &quot;2023-11-28T16:11:22.819244&quot;,
       &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ],
       &quot;title&quot; : &quot;일기 2 제목&quot;,
       &quot;content&quot; : &quot;일기 2 내용&quot;
@@ -2476,7 +2610,7 @@ Content-Length: 564
       &quot;id&quot; : 1,
       &quot;date&quot; : &quot;2023-11-27&quot;,
       &quot;dogName&quot; : &quot;코코&quot;,
-      &quot;createdAt&quot; : &quot;2023-11-28T14:19:22.986671&quot;,
+      &quot;createdAt&quot; : &quot;2023-11-28T16:11:22.819231&quot;,
       &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ],
       &quot;title&quot; : &quot;일기 1 제목&quot;,
       &quot;content&quot; : &quot;일기 1 내용&quot;
@@ -2491,7 +2625,7 @@ Content-Length: 564
 <div class="paragraph">
 <p>일기 id를 통해 일기 하나를 조회합니다.</p>
 </div>
-<h4 id="_요청_24" class="discrete">요청</h4>
+<h4 id="_요청_25" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries/1 HTTP/1.1
@@ -2518,7 +2652,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_24" class="discrete">응답</h4>
+<h4 id="_응답_25" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2526,7 +2660,7 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 281
+Content-Length: 280
 
 {
   &quot;code&quot; : &quot;0000&quot;,
@@ -2535,7 +2669,7 @@ Content-Length: 281
     &quot;id&quot; : 1,
     &quot;date&quot; : &quot;2023-11-27&quot;,
     &quot;dogName&quot; : &quot;코코&quot;,
-    &quot;createdAt&quot; : &quot;2023-11-28T14:19:23.090648&quot;,
+    &quot;createdAt&quot; : &quot;2023-11-28T16:11:22.93523&quot;,
     &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ],
     &quot;title&quot; : &quot;일기 1 제목&quot;,
     &quot;content&quot; : &quot;일기 1 내용&quot;
@@ -2549,7 +2683,7 @@ Content-Length: 281
 <div class="paragraph">
 <p>일기를 생성합니다.</p>
 </div>
-<h4 id="_요청_25" class="discrete">요청</h4>
+<h4 id="_요청_26" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/diaries HTTP/1.1
@@ -2622,7 +2756,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_25" class="discrete">응답</h4>
+<h4 id="_응답_26" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
@@ -2647,7 +2781,7 @@ Content-Length: 81
 <div class="paragraph">
 <p>일기 날짜, 제목, 내용, 이미지를 수정합니다.</p>
 </div>
-<h4 id="_요청_26" class="discrete">요청</h4>
+<h4 id="_요청_27" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">PUT /api/v1/diaries/1 HTTP/1.1
@@ -2739,7 +2873,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_26" class="discrete">응답</h4>
+<h4 id="_응답_27" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2762,7 +2896,7 @@ Content-Length: 62
 <div class="paragraph">
 <p>일기 id를 통해 일기를 삭제합니다.</p>
 </div>
-<h4 id="_요청_27" class="discrete">요청</h4>
+<h4 id="_요청_28" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/diaries/1 HTTP/1.1
@@ -2789,7 +2923,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_27" class="discrete">응답</h4>
+<h4 id="_응답_28" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2812,7 +2946,7 @@ Content-Length: 62
 <div class="paragraph">
 <p>일기 id를 통해 일기 공유용 UUID를 조회합니다.</p>
 </div>
-<h4 id="_요청_28" class="discrete">요청</h4>
+<h4 id="_요청_29" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries/1/share-uuid HTTP/1.1
@@ -2839,7 +2973,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_28" class="discrete">응답</h4>
+<h4 id="_응답_29" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2853,7 +2987,7 @@ Content-Length: 115
   &quot;code&quot; : &quot;0000&quot;,
   &quot;message&quot; : &quot;정상&quot;,
   &quot;data&quot; : {
-    &quot;uuid&quot; : &quot;fb2b814d-19ab-49e7-a3f6-300b3eefbf82&quot;
+    &quot;uuid&quot; : &quot;dc0f5371-db20-45e2-9f7a-28d71f202aeb&quot;
   }
 }</code></pre>
 </div>
@@ -2864,7 +2998,7 @@ Content-Length: 115
 <div class="paragraph">
 <p>일기 UUID를 통해 일기를 조회합니다. 인증 헤더가 필요하지 않습니다.</p>
 </div>
-<h4 id="_요청_29" class="discrete">요청</h4>
+<h4 id="_요청_30" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries/shared/1 HTTP/1.1
@@ -2890,7 +3024,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_29" class="discrete">응답</h4>
+<h4 id="_응답_30" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2907,7 +3041,7 @@ Content-Length: 281
     &quot;id&quot; : 1,
     &quot;date&quot; : &quot;2023-11-27&quot;,
     &quot;dogName&quot; : &quot;코코&quot;,
-    &quot;createdAt&quot; : &quot;2023-11-28T14:19:23.115682&quot;,
+    &quot;createdAt&quot; : &quot;2023-11-28T16:11:22.979808&quot;,
     &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ],
     &quot;title&quot; : &quot;일기 1 제목&quot;,
     &quot;content&quot; : &quot;일기 1 내용&quot;
@@ -2929,14 +3063,14 @@ Content-Length: 281
 <div class="paragraph">
 <p>전체 공지를 조회합니다. 최신순으로 정렬됩니다. 별도의 인증이 필요 없습니다.</p>
 </div>
-<h4 id="_요청_30" class="discrete">요청</h4>
+<h4 id="_요청_31" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/notices HTTP/1.1
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
-<h4 id="_응답_30" class="discrete">응답</h4>
+<h4 id="_응답_31" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2954,12 +3088,12 @@ Content-Length: 374
       &quot;id&quot; : 2,
       &quot;title&quot; : &quot;공지 2 제목&quot;,
       &quot;content&quot; : &quot;공지 2 내용&quot;,
-      &quot;createdAt&quot; : &quot;2023-11-28T14:19:24.192948&quot;
+      &quot;createdAt&quot; : &quot;2023-11-28T16:11:24.274895&quot;
     }, {
       &quot;id&quot; : 1,
       &quot;title&quot; : &quot;공지 1 제목&quot;,
       &quot;content&quot; : &quot;공지 1 내용&quot;,
-      &quot;createdAt&quot; : &quot;2023-11-27T14:19:24.192933&quot;
+      &quot;createdAt&quot; : &quot;2023-11-27T16:11:24.274881&quot;
     } ]
   }
 }</code></pre>

--- a/src/test/java/com/meommu/meommuapi/gpt/controller/GptControllerTest.java
+++ b/src/test/java/com/meommu/meommuapi/gpt/controller/GptControllerTest.java
@@ -23,6 +23,8 @@ import com.meommu.meommuapi.gpt.dto.GptGenerateRequest;
 import com.meommu.meommuapi.gpt.dto.GptGenerateResponse;
 import com.meommu.meommuapi.util.ControllerTest;
 
+import reactor.core.publisher.Flux;
+
 @DisplayName("GPT API")
 class GptControllerTest extends ControllerTest {
 
@@ -52,6 +54,111 @@ class GptControllerTest extends ControllerTest {
 			jsonPath("$.data.content").value("생성된 일기 내용")
 		).andDo(
 			document("gpt/create/success",
+				getDocumentRequest(), getDocumentResponse(),
+				requestFields(
+					fieldWithPath("details").type(JsonFieldType.STRING).description("일기 생성을 위한 디테일")
+						.attributes(
+							getConstraints("constraints", "일기 디테일은 최소 1개이상 존재해야하며, 디테일들은 파이프(|)로 구분되어야 합니다."))
+				)
+			)
+		);
+	}
+
+	@DisplayName("GPT Stream 생성: 성공 -> 201")
+	@Test
+	void testCreateGptContentStream() throws Exception {
+		// given
+		GptGenerateRequest gptGenerateRequest = GptGenerateRequest.builder()
+			.details("수영장에서 친구랑 놀기|맛있는 간식 먹기")
+			.build();
+		var response1 = """
+			    {
+			        "id": "chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM",
+			        "object": "chat.completion.chunk",
+			        "created": 1701149452,
+			        "model": "gpt-3.5-turbo-0613",
+			        "choices": [
+			            {
+			                "index": 0,
+			                "delta": {
+			                    "role": "assistant",
+			                    "content": ""
+			                },
+			                "finish_reason": null
+			            }
+			        ]
+			    }
+			""";
+		var response2 = """
+			    {
+			        "id": "chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM",
+			        "object": "chat.completion.chunk",
+			        "created": 1701149452,
+			        "model": "gpt-3.5-turbo-0613",
+			        "choices": [
+			            {
+			                "index": 0,
+			                "delta": {
+			                    "content": "일"
+			                },
+			                "finish_reason": null
+			            }
+			        ]
+			    }
+			""";
+		var response3 = """
+			    {
+			        "id": "chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM",
+			        "object": "chat.completion.chunk",
+			        "created": 1701149452,
+			        "model": "gpt-3.5-turbo-0613",
+			        "choices": [
+			            {
+			                "index": 0,
+			                "delta": {
+			                    "content": "기"
+			                },
+			                "finish_reason": null
+			            }
+			        ]
+			    }
+			""";
+		var response4 = """
+			    {
+			        "id": "chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM",
+			        "object": "chat.completion.chunk",
+			        "created": 1701149452,
+			        "model": "gpt-3.5-turbo-0613",
+			        "choices": [
+			            {
+			                "index": 0,
+			                "delta": {},
+			                "finish_reason": "stop"
+			            }
+			        ]
+			    }
+			""";
+		var response5 = """
+			    {
+			        "[DONE]"
+			    }
+			""";
+
+		var responseSource = Flux.just(response1, response2, response3, response4, response5);
+
+		given(gptService.createGptContentStream(any())).willReturn(responseSource);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/v1/gpt/stream")
+			.header(AUTHORIZATION, ACCESS_TOKEN_WITH_BEARER)
+			.content(JsonUtils.toJson(gptGenerateRequest))
+			.contentType(MediaType.APPLICATION_JSON_VALUE));
+
+		// then
+		resultActions.andExpectAll(
+			status().isCreated()
+		).andDo(
+			document("gpt/create-stream/success",
 				getDocumentRequest(), getDocumentResponse(),
 				requestFields(
 					fieldWithPath("details").type(JsonFieldType.STRING).description("일기 생성을 위한 디테일")


### PR DESCRIPTION
### 💁‍♂️ PR 개요
- #45 에 명시된 기능을 구현했습니다.
<br/>   

### 📝 변경 사항
- **POST** `/api/v1/gpt/stream` 으로 GPT 일기 생성을 요청할 경우 stream방식으로 한 글자씩 응답합니다. aa8847532b366ab965c260d527924cf5f4081694
- 응답 형식은 아래와 같습니다.
```
data:    {
        "id": "chatcmpl-8PkyK7PqVwezCANDoBBe8wa07h8MM",
        "object": "chat.completion.chunk",
        "created": 1701149452,
        "model": "gpt-3.5-turbo-0613",
        "choices": [
            {
                "index": 0,
                "delta": {
                    "content": "일"
                },
                "finish_reason": null
            }
        ]
    }
```
- 실제 데이터는 data>choices>delta>content에 담기며, 종료 상황이 발생한 경우 finish_reason에 종료 상황이 명시되고 연결이 종료됩니다.
<br/>

### 📷 스크린 샷 (선택)
- Postman을 통한 테스트시 아래와 같이 응답이 발생합니다.
- 종료될 경우 finish_reason에 null이 아닌 종료 이유가 명시되며 [DONE]을 통해 연결을 종료합니다.
<img width="761" alt="image" src="https://github.com/Meommu/meommu-api/assets/97517890/63a5e038-1a8b-4b80-97dd-33589c988fb3">

<br/>

### 🗣 리뷰어한테 할 말 (선택)
- 
<br/>

### 🧪 테스트 범위 (선택)
- 컨트롤러 테스트를 작성했습니다.
<br/> 
