### PR TITLE
Redis 도입, 로그아웃, 토큰 재발급 기능 구현

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       S3_SECRET_KEY: ${S3_SECRET_KEY}
       S3_END_POINT: ${S3_END_POINT}
       GPT_API_KEY: ${GPT_API_KEY}
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PORT: ${REDIS_PORT}
 
   green:
     container_name: green
@@ -38,3 +40,5 @@ services:
       S3_SECRET_KEY: ${S3_SECRET_KEY}
       S3_END_POINT: ${S3_END_POINT}
       GPT_API_KEY: ${GPT_API_KEY}
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PORT: ${REDIS_PORT}

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -26,10 +26,6 @@ jobs:
       - name: Set up Environment
         run: echo "${{ secrets.PROD_ENV_PROPERTIES }}" > ./.env
 
-      # 로깅 추가: .env 파일 내용 확인
-      - name: Display .env File Contents
-        run: cat .env
-
       # 환경 변수 파일 서버로 전달
       - name: Send env file
         uses: appleboy/scp-action@master

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
 	// JWT

--- a/src/docs/asciidoc/kindergarten.adoc
+++ b/src/docs/asciidoc/kindergarten.adoc
@@ -48,6 +48,31 @@ include::{snippets}/kindergartens/signIn/success/request-fields.adoc[]
 include::{snippets}/kindergartens/signIn/success/http-response.adoc[]
 
 
+=== 로그아웃
+로그아웃을 진행합니다.
+
+[discrete]
+==== 요청
+include::{snippets}/kindergartens/signOut/success/http-request.adoc[]
+
+[discrete]
+==== 응답
+include::{snippets}/kindergartens/signOut/success/http-response.adoc[]
+
+
+=== 토큰 재발급
+Access Token과 Refresh Token의 재발급을 진행합니다.
+
+[discrete]
+==== 요청
+include::{snippets}/kindergartens/reissue/success/http-request.adoc[]
+include::{snippets}/kindergartens/reissue/success/request-fields.adoc[]
+
+[discrete]
+==== 응답
+include::{snippets}/kindergartens/reissue/success/http-response.adoc[]
+
+
 === 로그인 정보 조회
 accessToken을 통해 로그인한 회원의 회원 id, 유치원 이름, 이메일을 조회합니다.
 
@@ -58,6 +83,7 @@ include::{snippets}/kindergartens/me/success/http-request.adoc[]
 [discrete]
 ==== 응답
 include::{snippets}/kindergartens/me/success/http-response.adoc[]
+
 
 === 회원 정보 조회
 회원 상세 정보를 조회합니다.

--- a/src/main/java/com/meommu/meommuapi/core/auth/controller/AuthController.java
+++ b/src/main/java/com/meommu/meommuapi/core/auth/controller/AuthController.java
@@ -1,14 +1,18 @@
 package com.meommu.meommuapi.core.auth.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.meommu.meommuapi.core.auth.dto.AuthInfo;
+import com.meommu.meommuapi.core.auth.dto.ReissueRequest;
 import com.meommu.meommuapi.core.auth.dto.SignInRequest;
 import com.meommu.meommuapi.core.auth.dto.TokenResponse;
 import com.meommu.meommuapi.core.auth.service.AuthService;
+import com.meommu.meommuapi.core.auth.token.Auth;
 
 import jakarta.validation.Valid;
 
@@ -25,5 +29,16 @@ public class AuthController {
 	@PostMapping("/api/v1/kindergartens/signin")
 	public TokenResponse signIn(@Valid @RequestBody SignInRequest signInRequest) {
 		return authService.signIn(signInRequest);
+	}
+
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping("/api/v1/kindergartens/reissue")
+	public TokenResponse reissue(@Auth AuthInfo authInfo, @Valid @RequestBody ReissueRequest reissueRequest) {
+		return authService.reissue(authInfo, reissueRequest);
+	}
+
+	@DeleteMapping("/api/v1/kindergartens/signout")
+	public void signOut(@Auth AuthInfo authInfo) {
+		authService.signOut(authInfo);
 	}
 }

--- a/src/main/java/com/meommu/meommuapi/core/auth/dto/ReissueRequest.java
+++ b/src/main/java/com/meommu/meommuapi/core/auth/dto/ReissueRequest.java
@@ -1,0 +1,20 @@
+package com.meommu.meommuapi.core.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReissueRequest {
+
+	@NotBlank(message = "refreshToken은 반드시 입력해야 합니다.")
+	private String refreshToken;
+
+	private ReissueRequest() {
+	}
+
+	@Builder
+	public ReissueRequest(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/meommu/meommuapi/core/auth/dto/TokenResponse.java
+++ b/src/main/java/com/meommu/meommuapi/core/auth/dto/TokenResponse.java
@@ -8,16 +8,19 @@ public class TokenResponse {
 
 	private String accessToken;
 
+	private String refreshToken;
+
 	private TokenResponse() {
 	}
 
 	@Builder
-	private TokenResponse(String accessToken) {
+	private TokenResponse(String accessToken, String refreshToken) {
 		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
 	}
 
-	public static TokenResponse from(String accessToken) {
-		return new TokenResponse(accessToken);
+	public static TokenResponse from(String accessToken, String refreshToken) {
+		return new TokenResponse(accessToken, refreshToken);
 	}
 
 }

--- a/src/main/java/com/meommu/meommuapi/core/auth/service/AuthService.java
+++ b/src/main/java/com/meommu/meommuapi/core/auth/service/AuthService.java
@@ -1,14 +1,26 @@
 package com.meommu.meommuapi.core.auth.service;
 
-import org.springframework.stereotype.Service;
+import static com.meommu.meommuapi.core.auth.exception.errorCode.AuthErrorCode.*;
 
+import javax.naming.AuthenticationException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.meommu.meommuapi.core.auth.dto.AuthInfo;
+import com.meommu.meommuapi.core.auth.dto.ReissueRequest;
 import com.meommu.meommuapi.core.auth.dto.SignInRequest;
 import com.meommu.meommuapi.core.auth.dto.TokenResponse;
+import com.meommu.meommuapi.core.auth.exception.AuthorizationException;
+import com.meommu.meommuapi.core.auth.exception.JwtException;
 import com.meommu.meommuapi.core.auth.exception.SignInFailedException;
 import com.meommu.meommuapi.core.auth.token.JwtTokenProvider;
 import com.meommu.meommuapi.core.kindergarten.domain.Kindergarten;
 import com.meommu.meommuapi.core.kindergarten.domain.embedded.Encryptor;
 import com.meommu.meommuapi.core.kindergarten.repository.KindergartenRepository;
+import com.meommu.meommuapi.global.infra.redis.util.RedisUtils;
+
+import jakarta.security.auth.message.AuthException;
 
 @Service
 public class AuthService {
@@ -19,17 +31,57 @@ public class AuthService {
 
 	private final JwtTokenProvider jwtTokenProvider;
 
+	private final RedisUtils redisUtils;
+
 	public AuthService(KindergartenRepository kindergartenRepository, Encryptor encryptor,
-		JwtTokenProvider jwtTokenProvider) {
+		JwtTokenProvider jwtTokenProvider, RedisUtils redisUtils) {
 		this.kindergartenRepository = kindergartenRepository;
 		this.encryptor = encryptor;
 		this.jwtTokenProvider = jwtTokenProvider;
+		this.redisUtils = redisUtils;
 	}
 
-	public TokenResponse signIn(SignInRequest signInRequest) {
-		Kindergarten kindergarten = kindergartenRepository.findByEmailValueAndPasswordValue(signInRequest.getEmail(),
-			encryptor.encrypt(signInRequest.getPassword())).orElseThrow(() -> new SignInFailedException());
+	@Transactional
+	public TokenResponse signIn(SignInRequest request) {
+		Kindergarten kindergarten = kindergartenRepository.findByEmailValueAndPasswordValue(request.getEmail(),
+			encryptor.encrypt(request.getPassword())).orElseThrow(() -> new SignInFailedException());
 		String accessToken = jwtTokenProvider.createAccessToken(kindergarten.getId());
-		return TokenResponse.from(accessToken);
+		String refreshToken = jwtTokenProvider.createRefreshToken(kindergarten.getId());
+
+		Long expiration = jwtTokenProvider.getExpiration(refreshToken);
+		redisUtils.setRefreshToken(kindergarten.getId(), refreshToken, expiration);
+
+		return TokenResponse.from(accessToken, refreshToken);
+	}
+
+	@Transactional
+	public TokenResponse reissue(AuthInfo authInfo, ReissueRequest request) {
+		// 1. Refresh Token 검증
+		jwtTokenProvider.validateRefreshToken(request.getRefreshToken());
+
+		// 2. 인증정보
+		Long id = authInfo.getId();
+
+		// 3. Redis RefreshToken 조회
+		String refreshToken = redisUtils.getRefreshToken(id);
+		if (!refreshToken.equals(request.getRefreshToken())) {
+			throw new JwtException(MALFORMED_JWT);
+		}
+
+		// 3. 새로운 토큰 발급
+		String newAccessToken = jwtTokenProvider.createAccessToken(id);
+		String newRefreshToken = jwtTokenProvider.createRefreshToken(id);
+
+		// 4. Redis RefreshToken 업데이트
+		Long expiration = jwtTokenProvider.getExpiration(refreshToken);
+		redisUtils.setRefreshToken(id, newRefreshToken, expiration);
+
+		// 5. 토큰 반환
+		return TokenResponse.from(newAccessToken, newRefreshToken);
+	}
+
+	@Transactional
+	public void signOut(AuthInfo authInfo) {
+		redisUtils.deleteRefreshToken(authInfo.getId());
 	}
 }

--- a/src/main/java/com/meommu/meommuapi/global/config/WebMvcConfig.java
+++ b/src/main/java/com/meommu/meommuapi/global/config/WebMvcConfig.java
@@ -46,6 +46,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 			.addPathPatterns("/**")
 			.excludePathPatterns("/api/v1/kindergartens/signin")
 			.excludePathPatterns("/api/v1/kindergartens/signup")
+			.excludePathPatterns("/api/v1/kindergartens/reissue")
 			.excludePathPatterns("/api/v1/kindergartens/email/**")
 			.excludePathPatterns("/api/v1/kindergartens/password")
 			.excludePathPatterns("/api/v1/images/**")

--- a/src/main/java/com/meommu/meommuapi/global/infra/redis/config/RedisConfig.java
+++ b/src/main/java/com/meommu/meommuapi/global/infra/redis/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.meommu.meommuapi.global.infra.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory(){
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<?,?> redisTemplate(){
+		RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/meommu/meommuapi/global/infra/redis/util/RedisUtils.java
+++ b/src/main/java/com/meommu/meommuapi/global/infra/redis/util/RedisUtils.java
@@ -1,0 +1,31 @@
+package com.meommu.meommuapi.global.infra.redis.util;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisUtils {
+	private final RedisTemplate<String, Object> refreshTokenTemplate; // 리프레시 토큰 저장용 RedisTemplate
+
+	public RedisUtils(RedisTemplate<String, Object> refreshTokenTemplate) {
+		this.refreshTokenTemplate = refreshTokenTemplate;
+	}
+
+	public void setRefreshToken(Long userId, String refreshToken, long milliseconds) {
+		String key = "refresh_token:" + userId;
+		refreshTokenTemplate.opsForValue().set(key, refreshToken, milliseconds, TimeUnit.MILLISECONDS);
+	}
+
+	public String getRefreshToken(Long userId) {
+		String key = "refresh_token:" + userId;
+		return String.valueOf(refreshTokenTemplate.opsForValue().get(key));
+	}
+
+	public boolean deleteRefreshToken(Long userId) {
+		String key = "refresh_token:" + userId;
+		Boolean isDeleted = refreshTokenTemplate.delete(key);
+		return isDeleted != null && isDeleted;
+	}
+}

--- a/src/main/java/com/meommu/meommuapi/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/meommu/meommuapi/global/interceptor/AuthInterceptor.java
@@ -33,7 +33,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 
 		validateAuthorizationHeader(request);
 
-		jwtTokenProvider.validateToken(JwtTokenExtractor.extractAccessToken(request));
+		jwtTokenProvider.validateAccessToken(JwtTokenExtractor.extractAccessToken(request));
 
 		return true;
 	}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -29,6 +29,10 @@ spring:
           timeout: 5000
           writetimeout: 5000
     auth-code-expiration-millis: 1800000
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 security:
   jwt:
@@ -36,6 +40,7 @@ security:
       secret-key: ${JWT_SECRET_KEY}
       expire-length:
         access: 604800000
+        refresh: 604600000
 
 cloud:
   aws:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,6 +29,10 @@ spring:
           timeout: 5000
           writetimeout: 5000
     auth-code-expiration-millis: 1800000
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 security:
   jwt:
@@ -36,6 +40,7 @@ security:
       secret-key: ${JWT_SECRET_KEY}
       expire-length:
         access: 604800000
+        refresh: 604600000
 
 cloud:
   aws:

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -555,13 +555,15 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <li><a href="#_이메일_중복확인">2.1. 이메일 중복확인</a></li>
 <li><a href="#_회원가입">2.2. 회원가입</a></li>
 <li><a href="#_로그인">2.3. 로그인</a></li>
-<li><a href="#_로그인_정보_조회">2.4. 로그인 정보 조회</a></li>
-<li><a href="#_회원_정보_조회">2.5. 회원 정보 조회</a></li>
-<li><a href="#_회원_정보_수정">2.6. 회원 정보 수정</a></li>
-<li><a href="#_회원_탈퇴">2.7. 회원 탈퇴</a></li>
-<li><a href="#_비밀번호_찾기_이메일_전송">2.8. 비밀번호 찾기 - 이메일 전송</a></li>
-<li><a href="#_비밀번호_찾기_인증_코드_확인">2.9. 비밀번호 찾기 - 인증 코드 확인</a></li>
-<li><a href="#_비밀번호_찾기_수정">2.10. 비밀번호 찾기 - 수정</a></li>
+<li><a href="#_로그아웃">2.4. 로그아웃</a></li>
+<li><a href="#_토큰_재발급">2.5. 토큰 재발급</a></li>
+<li><a href="#_로그인_정보_조회">2.6. 로그인 정보 조회</a></li>
+<li><a href="#_회원_정보_조회">2.7. 회원 정보 조회</a></li>
+<li><a href="#_회원_정보_수정">2.8. 회원 정보 수정</a></li>
+<li><a href="#_회원_탈퇴">2.9. 회원 탈퇴</a></li>
+<li><a href="#_비밀번호_찾기_이메일_전송">2.10. 비밀번호 찾기 - 이메일 전송</a></li>
+<li><a href="#_비밀번호_찾기_인증_코드_확인">2.11. 비밀번호 찾기 - 인증 코드 확인</a></li>
+<li><a href="#_비밀번호_찾기_수정">2.12. 비밀번호 찾기 - 수정</a></li>
 </ul>
 </li>
 <li><a href="#_이미지">3. 이미지</a>
@@ -1241,7 +1243,7 @@ Content-Length: 189
     &quot;id&quot; : 1,
     &quot;name&quot; : &quot;멈무유치원&quot;,
     &quot;email&quot; : &quot;meommu@exam.com&quot;,
-    &quot;createdAt&quot; : &quot;2023-12-14T15:53:39.564961&quot;
+    &quot;createdAt&quot; : &quot;2024-01-10T14:56:05.035211&quot;
   }
 }</code></pre>
 </div>
@@ -1308,27 +1310,29 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 100
+Content-Length: 140
 
 {
   &quot;code&quot; : &quot;0000&quot;,
   &quot;message&quot; : &quot;정상&quot;,
   &quot;data&quot; : {
-    &quot;accessToken&quot; : &quot;&lt;ACCESS_TOKEN&gt;&quot;
+    &quot;accessToken&quot; : &quot;&lt;ACCESS_TOKEN&gt;&quot;,
+    &quot;refreshToken&quot; : &quot;&lt;REFRESH_TOKEN&gt;&quot;
   }
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_로그인_정보_조회"><a class="link" href="#_로그인_정보_조회">2.4. 로그인 정보 조회</a></h3>
+<h3 id="_로그아웃"><a class="link" href="#_로그아웃">2.4. 로그아웃</a></h3>
 <div class="paragraph">
-<p>accessToken을 통해 로그인한 회원의 회원 id, 유치원 이름, 이메일을 조회합니다.</p>
+<p>로그아웃을 진행합니다.</p>
 </div>
 <h4 id="_요청_4" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/kindergartens/me HTTP/1.1
+<pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/kindergartens/signout HTTP/1.1
+Content-Type: application/json;charset=UTF-8
 Authorization: Bearer &lt;ACCESS_TOKEN&gt;
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
@@ -1341,7 +1345,105 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 187
+Content-Length: 62
+
+{
+  &quot;code&quot; : &quot;0000&quot;,
+  &quot;message&quot; : &quot;정상&quot;,
+  &quot;data&quot; : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_토큰_재발급"><a class="link" href="#_토큰_재발급">2.5. 토큰 재발급</a></h3>
+<div class="paragraph">
+<p>Access Token과 Refresh Token의 재발급을 진행합니다.</p>
+</div>
+<h4 id="_요청_5" class="discrete">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/kindergartens/reissue HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer &lt;ACCESS_TOKEN&gt;
+Content-Length: 40
+Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
+
+{
+  &quot;refreshToken&quot; : &quot;&lt;REFRESH_TOKEN&gt;&quot;
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">제약사항</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>refreshToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">refresh token</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+<h4 id="_응답_5" class="discrete">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 140
+
+{
+  &quot;code&quot; : &quot;0000&quot;,
+  &quot;message&quot; : &quot;정상&quot;,
+  &quot;data&quot; : {
+    &quot;accessToken&quot; : &quot;&lt;ACCESS_TOKEN&gt;&quot;,
+    &quot;refreshToken&quot; : &quot;&lt;REFRESH_TOKEN&gt;&quot;
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_로그인_정보_조회"><a class="link" href="#_로그인_정보_조회">2.6. 로그인 정보 조회</a></h3>
+<div class="paragraph">
+<p>accessToken을 통해 로그인한 회원의 회원 id, 유치원 이름, 이메일을 조회합니다.</p>
+</div>
+<h4 id="_요청_6" class="discrete">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/kindergartens/me HTTP/1.1
+Authorization: Bearer &lt;ACCESS_TOKEN&gt;
+Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
+</div>
+</div>
+<h4 id="_응답_6" class="discrete">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 189
 
 {
   &quot;code&quot; : &quot;0000&quot;,
@@ -1350,18 +1452,18 @@ Content-Length: 187
     &quot;id&quot; : 1,
     &quot;name&quot; : &quot;멈무유치원&quot;,
     &quot;email&quot; : &quot;meommu@exam.com&quot;,
-    &quot;createdAt&quot; : &quot;2023-12-14T15:53:39.594096&quot;
+    &quot;createdAt&quot; : &quot;2024-01-10T14:56:05.081881&quot;
   }
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_회원_정보_조회"><a class="link" href="#_회원_정보_조회">2.5. 회원 정보 조회</a></h3>
+<h3 id="_회원_정보_조회"><a class="link" href="#_회원_정보_조회">2.7. 회원 정보 조회</a></h3>
 <div class="paragraph">
 <p>회원 상세 정보를 조회합니다.</p>
 </div>
-<h4 id="_요청_5" class="discrete">요청</h4>
+<h4 id="_요청_7" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/kindergartens/info HTTP/1.1
@@ -1369,7 +1471,7 @@ Authorization: Bearer &lt;ACCESS_TOKEN&gt;
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
-<h4 id="_응답_5" class="discrete">응답</h4>
+<h4 id="_응답_7" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -1394,11 +1496,11 @@ Content-Length: 203
 </div>
 </div>
 <div class="sect2">
-<h3 id="_회원_정보_수정"><a class="link" href="#_회원_정보_수정">2.6. 회원 정보 수정</a></h3>
+<h3 id="_회원_정보_수정"><a class="link" href="#_회원_정보_수정">2.8. 회원 정보 수정</a></h3>
 <div class="paragraph">
 <p>회원 상세 정보를 수정합니다. 유치원 이름, 대표자 이름, 전화번호를 수정합니다.</p>
 </div>
-<h4 id="_요청_6" class="discrete">요청</h4>
+<h4 id="_요청_8" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">PATCH /api/v1/kindergartens/info HTTP/1.1
@@ -1414,92 +1516,6 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 }</code></pre>
 </div>
 </div>
-<h4 id="_응답_6" class="discrete">응답</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json;charset=UTF-8
-Content-Length: 62
-
-{
-  &quot;code&quot; : &quot;0000&quot;,
-  &quot;message&quot; : &quot;정상&quot;,
-  &quot;data&quot; : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_회원_탈퇴"><a class="link" href="#_회원_탈퇴">2.7. 회원 탈퇴</a></h3>
-<div class="paragraph">
-<p>회원탈퇴를 진행합니다.</p>
-</div>
-<h4 id="_요청_7" class="discrete">요청</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/kindergartens HTTP/1.1
-Authorization: bearer &lt;ACCESS_TOKEN&gt;
-Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
-</div>
-</div>
-<h4 id="_응답_7" class="discrete">응답</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json;charset=UTF-8
-Content-Length: 62
-
-{
-  &quot;code&quot; : &quot;0000&quot;,
-  &quot;message&quot; : &quot;정상&quot;,
-  &quot;data&quot; : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_비밀번호_찾기_이메일_전송"><a class="link" href="#_비밀번호_찾기_이메일_전송">2.8. 비밀번호 찾기 - 이메일 전송</a></h3>
-<div class="paragraph">
-<p>비밀번호를 수정하기 위해 인증 코드를 이메일로 전송합니다.</p>
-</div>
-<h4 id="_요청_8" class="discrete">요청</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/kindergartens/email/verification-request?email=meommu@email.com HTTP/1.1
-Content-Type: application/x-www-form-urlencoded
-Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">파라미터</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-<th class="tableblock halign-left valign-top">제약사항</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호를 수정하고자 하는 이메일</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-</tbody>
-</table>
 <h4 id="_응답_8" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
@@ -1519,49 +1535,19 @@ Content-Length: 62
 </div>
 </div>
 <div class="sect2">
-<h3 id="_비밀번호_찾기_인증_코드_확인"><a class="link" href="#_비밀번호_찾기_인증_코드_확인">2.9. 비밀번호 찾기 - 인증 코드 확인</a></h3>
+<h3 id="_회원_탈퇴"><a class="link" href="#_회원_탈퇴">2.9. 회원 탈퇴</a></h3>
 <div class="paragraph">
-<p>비밀번호를 수정하기 위해 이메일로 전송된 인증 코드를 확인합니다.</p>
+<p>회원탈퇴를 진행합니다.</p>
 </div>
 <h4 id="_요청_9" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/kindergartens/email/verification?email=meommu@email.com&amp;code=123456 HTTP/1.1
+<pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/kindergartens HTTP/1.1
+Authorization: bearer &lt;ACCESS_TOKEN&gt;
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">파라미터</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-<th class="tableblock halign-left valign-top">제약사항</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호를 수정하고자 하는 이메일</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이메일로 받은 코드</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6글자의 숫자 입니다.</p></td>
-</tr>
-</tbody>
-</table>
 <h4 id="_응답_9" class="discrete">응답</h4>
-<h5 id="_일치할_경우" class="discrete">일치할 경우</h5>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -1574,45 +1560,22 @@ Content-Length: 62
 {
   &quot;code&quot; : &quot;0000&quot;,
   &quot;message&quot; : &quot;정상&quot;,
-  &quot;data&quot; : true
-}</code></pre>
-</div>
-</div>
-<h5 id="_불일치할_경우" class="discrete">불일치할 경우</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json;charset=UTF-8
-Content-Length: 63
-
-{
-  &quot;code&quot; : &quot;0000&quot;,
-  &quot;message&quot; : &quot;정상&quot;,
-  &quot;data&quot; : false
+  &quot;data&quot; : null
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_비밀번호_찾기_수정"><a class="link" href="#_비밀번호_찾기_수정">2.10. 비밀번호 찾기 - 수정</a></h3>
+<h3 id="_비밀번호_찾기_이메일_전송"><a class="link" href="#_비밀번호_찾기_이메일_전송">2.10. 비밀번호 찾기 - 이메일 전송</a></h3>
 <div class="paragraph">
-<p>비밀번호를 수정합니다. 인증 코드 확인이 완료된 이메일 대상으로 수정 기능을 제공합니다. 별도의 인증 과정이 생략되었습니다.</p>
+<p>비밀번호를 수정하기 위해 인증 코드를 이메일로 전송합니다.</p>
 </div>
 <h4 id="_요청_10" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">PATCH /api/v1/kindergartens/password?email=meommu@email.com HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Content-Length: 72
-Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
-
-{
-  &quot;password&quot; : &quot;Password1!&quot;,
-  &quot;passwordConfirmation&quot; : &quot;Password1!&quot;
-}</code></pre>
+<pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/kindergartens/email/verification-request?email=meommu@email.com HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1657,6 +1620,145 @@ Content-Length: 62
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_비밀번호_찾기_인증_코드_확인"><a class="link" href="#_비밀번호_찾기_인증_코드_확인">2.11. 비밀번호 찾기 - 인증 코드 확인</a></h3>
+<div class="paragraph">
+<p>비밀번호를 수정하기 위해 이메일로 전송된 인증 코드를 확인합니다.</p>
+</div>
+<h4 id="_요청_11" class="discrete">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/kindergartens/email/verification?email=meommu@email.com&amp;code=123456 HTTP/1.1
+Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">제약사항</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호를 수정하고자 하는 이메일</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일로 받은 코드</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6글자의 숫자 입니다.</p></td>
+</tr>
+</tbody>
+</table>
+<h4 id="_응답_11" class="discrete">응답</h4>
+<h5 id="_일치할_경우" class="discrete">일치할 경우</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 62
+
+{
+  &quot;code&quot; : &quot;0000&quot;,
+  &quot;message&quot; : &quot;정상&quot;,
+  &quot;data&quot; : true
+}</code></pre>
+</div>
+</div>
+<h5 id="_불일치할_경우" class="discrete">불일치할 경우</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 63
+
+{
+  &quot;code&quot; : &quot;0000&quot;,
+  &quot;message&quot; : &quot;정상&quot;,
+  &quot;data&quot; : false
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_찾기_수정"><a class="link" href="#_비밀번호_찾기_수정">2.12. 비밀번호 찾기 - 수정</a></h3>
+<div class="paragraph">
+<p>비밀번호를 수정합니다. 인증 코드 확인이 완료된 이메일 대상으로 수정 기능을 제공합니다. 별도의 인증 과정이 생략되었습니다.</p>
+</div>
+<h4 id="_요청_12" class="discrete">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">PATCH /api/v1/kindergartens/password?email=meommu@email.com HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 72
+Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
+
+{
+  &quot;password&quot; : &quot;Password1!&quot;,
+  &quot;passwordConfirmation&quot; : &quot;Password1!&quot;
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+<th class="tableblock halign-left valign-top">제약사항</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호를 수정하고자 하는 이메일</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+<h4 id="_응답_12" class="discrete">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 62
+
+{
+  &quot;code&quot; : &quot;0000&quot;,
+  &quot;message&quot; : &quot;정상&quot;,
+  &quot;data&quot; : null
+}</code></pre>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1670,7 +1772,7 @@ Content-Length: 62
 <div class="paragraph">
 <p>이미지 id를 통해 여러장을 조회합니다.</p>
 </div>
-<h4 id="_요청_11" class="discrete">요청</h4>
+<h4 id="_요청_13" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/images?id=1&amp;id=2 HTTP/1.1
@@ -1701,7 +1803,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_11" class="discrete">응답</h4>
+<h4 id="_응답_13" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -1732,7 +1834,7 @@ Content-Length: 199
 <div class="paragraph">
 <p>이미지 id를 통해 한 장을 조회합니다.</p>
 </div>
-<h4 id="_요청_12" class="discrete">요청</h4>
+<h4 id="_요청_14" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/images/1 HTTP/1.1
@@ -1758,7 +1860,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_12" class="discrete">응답</h4>
+<h4 id="_응답_14" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -1784,7 +1886,7 @@ Content-Length: 109
 <div class="paragraph">
 <p>이미지를 업로드 합니다.</p>
 </div>
-<h4 id="_요청_13" class="discrete">요청</h4>
+<h4 id="_요청_15" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/images HTTP/1.1
@@ -1832,7 +1934,7 @@ src/test/resources/testimages/coco.jpeg
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_13" class="discrete">응답</h4>
+<h4 id="_응답_15" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
@@ -1863,7 +1965,7 @@ Content-Length: 199
 <div class="paragraph">
 <p>이미지 id를 통해 여러 장을 삭제합니다.</p>
 </div>
-<h4 id="_요청_14" class="discrete">요청</h4>
+<h4 id="_요청_16" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/images?id=1&amp;id=2 HTTP/1.1
@@ -1895,7 +1997,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_14" class="discrete">응답</h4>
+<h4 id="_응답_16" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -1918,7 +2020,7 @@ Content-Length: 62
 <div class="paragraph">
 <p>이미지 id를 통해 한 장을 삭제합니다.</p>
 </div>
-<h4 id="_요청_15" class="discrete">요청</h4>
+<h4 id="_요청_17" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/images/1 HTTP/1.1
@@ -1944,7 +2046,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_15" class="discrete">응답</h4>
+<h4 id="_응답_17" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -1968,7 +2070,7 @@ Content-Length: 62
 <p>프록시를 이용하여 이미지를 byte로 변환합니다.
 Html2Canvas를 통한 이미지 캡쳐를 위해 사용됩니다.</p>
 </div>
-<h4 id="_요청_16" class="discrete">요청</h4>
+<h4 id="_요청_18" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/proxy?url=test.com HTTP/1.1
@@ -1999,7 +2101,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_16" class="discrete">응답</h4>
+<h4 id="_응답_18" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2026,7 +2128,7 @@ ByteValue</code></pre>
 <div class="paragraph">
 <p>GPT API를 통해 일기를 생성합니다.</p>
 </div>
-<h4 id="_요청_17" class="discrete">요청</h4>
+<h4 id="_요청_19" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/gpt HTTP/1.1
@@ -2067,7 +2169,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_17" class="discrete">응답</h4>
+<h4 id="_응답_19" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
@@ -2096,7 +2198,7 @@ Content-Length: 105
 <div class="paragraph">
 <p>실제 데이터는 data&gt;choices&gt;delta&gt;content에 담기며 종료 상황이 발생한 경우 finish_reason에 종료 상황이 명시되고 연결이 종료됩니다.</p>
 </div>
-<h4 id="_요청_18" class="discrete">요청</h4>
+<h4 id="_요청_20" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/gpt/stream HTTP/1.1
@@ -2137,7 +2239,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_18" class="discrete">응답</h4>
+<h4 id="_응답_20" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
@@ -2225,7 +2327,7 @@ data:    {
 <div class="paragraph">
 <p>GPT 일기 자동생성을 위한 일기 가이드를 조회합니다.</p>
 </div>
-<h4 id="_요청_19" class="discrete">요청</h4>
+<h4 id="_요청_21" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/guides HTTP/1.1
@@ -2233,7 +2335,7 @@ Authorization: Bearer &lt;ACCESS_TOKEN&gt;
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
-<h4 id="_응답_19" class="discrete">응답</h4>
+<h4 id="_응답_21" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2266,7 +2368,7 @@ Content-Length: 355
 <div class="paragraph">
 <p>GPT 일기 자동생성을 위한 일기 가이드 디테일을 조회합니다.</p>
 </div>
-<h4 id="_요청_20" class="discrete">요청</h4>
+<h4 id="_요청_22" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/guides/1/details HTTP/1.1
@@ -2293,7 +2395,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_20" class="discrete">응답</h4>
+<h4 id="_응답_22" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2324,7 +2426,7 @@ Content-Length: 226
 <div class="paragraph">
 <p>GPT 일기 자동생성을 위한 일기 가이드 디테일을 생성합니다.</p>
 </div>
-<h4 id="_요청_21" class="discrete">요청</h4>
+<h4 id="_요청_23" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/guides/1/details HTTP/1.1
@@ -2384,7 +2486,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_21" class="discrete">응답</h4>
+<h4 id="_응답_23" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2415,7 +2517,7 @@ Content-Length: 226
 <div class="paragraph">
 <p>GPT 일기 자동생성을 위한 일기 가이드 디테일을 삭제합니다.</p>
 </div>
-<h4 id="_요청_22" class="discrete">요청</h4>
+<h4 id="_요청_24" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/guides/1/details/1 HTTP/1.1
@@ -2446,7 +2548,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_22" class="discrete">응답</h4>
+<h4 id="_응답_24" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2478,7 +2580,7 @@ Content-Length: 62
 <p>일기 요약 정보를 조회합니다. 최신순으로 정렬됩니다.
 이미지 URL은 이미지 API를 통해 id로 조회하면 됩니다.</p>
 </div>
-<h4 id="_요청_23" class="discrete">요청</h4>
+<h4 id="_요청_25" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries/summary HTTP/1.1
@@ -2486,7 +2588,7 @@ Authorization: Bearer &lt;ACCESS_TOKEN&gt;
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
-<h4 id="_응답_23" class="discrete">응답</h4>
+<h4 id="_응답_25" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2502,13 +2604,13 @@ Content-Length: 364
   &quot;data&quot; : {
     &quot;diaries&quot; : [ {
       &quot;id&quot; : 2,
-      &quot;date&quot; : &quot;2023-12-14&quot;,
-      &quot;createdAt&quot; : &quot;2023-12-14T15:53:38.585346&quot;,
+      &quot;date&quot; : &quot;2024-01-10&quot;,
+      &quot;createdAt&quot; : &quot;2024-01-10T14:56:03.672824&quot;,
       &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ]
     }, {
       &quot;id&quot; : 1,
-      &quot;date&quot; : &quot;2023-12-13&quot;,
-      &quot;createdAt&quot; : &quot;2023-12-14T15:53:38.585336&quot;,
+      &quot;date&quot; : &quot;2024-01-09&quot;,
+      &quot;createdAt&quot; : &quot;2024-01-10T14:56:03.672804&quot;,
       &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ]
     } ]
   }
@@ -2522,10 +2624,10 @@ Content-Length: 364
 <p>일기를 년월별로 조회합니다. 최신순으로 정렬됩니다.
 이미지 URL은 이미지 API를 통해 id로 조회하면 됩니다.</p>
 </div>
-<h4 id="_요청_24" class="discrete">요청</h4>
+<h4 id="_요청_26" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries?year=2023&amp;month=12 HTTP/1.1
+<pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries?year=2024&amp;month=1 HTTP/1.1
 Authorization: Bearer &lt;ACCESS_TOKEN&gt;
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
@@ -2560,7 +2662,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_24" class="discrete">응답</h4>
+<h4 id="_응답_26" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2576,17 +2678,17 @@ Content-Length: 564
   &quot;data&quot; : {
     &quot;diaries&quot; : [ {
       &quot;id&quot; : 2,
-      &quot;date&quot; : &quot;2023-12-14&quot;,
+      &quot;date&quot; : &quot;2024-01-10&quot;,
       &quot;dogName&quot; : &quot;똘이&quot;,
-      &quot;createdAt&quot; : &quot;2023-12-14T15:53:38.535848&quot;,
+      &quot;createdAt&quot; : &quot;2024-01-10T14:56:03.618306&quot;,
       &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ],
       &quot;title&quot; : &quot;일기 2 제목&quot;,
       &quot;content&quot; : &quot;일기 2 내용&quot;
     }, {
       &quot;id&quot; : 1,
-      &quot;date&quot; : &quot;2023-12-13&quot;,
+      &quot;date&quot; : &quot;2024-01-09&quot;,
       &quot;dogName&quot; : &quot;코코&quot;,
-      &quot;createdAt&quot; : &quot;2023-12-14T15:53:38.535824&quot;,
+      &quot;createdAt&quot; : &quot;2024-01-10T14:56:03.618287&quot;,
       &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ],
       &quot;title&quot; : &quot;일기 1 제목&quot;,
       &quot;content&quot; : &quot;일기 1 내용&quot;
@@ -2601,7 +2703,7 @@ Content-Length: 564
 <div class="paragraph">
 <p>일기 id를 통해 일기 하나를 조회합니다.</p>
 </div>
-<h4 id="_요청_25" class="discrete">요청</h4>
+<h4 id="_요청_27" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries/1 HTTP/1.1
@@ -2628,7 +2730,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_25" class="discrete">응답</h4>
+<h4 id="_응답_27" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2636,16 +2738,16 @@ Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-Content-Length: 280
+Content-Length: 281
 
 {
   &quot;code&quot; : &quot;0000&quot;,
   &quot;message&quot; : &quot;정상&quot;,
   &quot;data&quot; : {
     &quot;id&quot; : 1,
-    &quot;date&quot; : &quot;2023-12-13&quot;,
+    &quot;date&quot; : &quot;2024-01-09&quot;,
     &quot;dogName&quot; : &quot;코코&quot;,
-    &quot;createdAt&quot; : &quot;2023-12-14T15:53:38.632715&quot;,
+    &quot;createdAt&quot; : &quot;2024-01-10T14:56:03.742172&quot;,
     &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ],
     &quot;title&quot; : &quot;일기 1 제목&quot;,
     &quot;content&quot; : &quot;일기 1 내용&quot;
@@ -2659,7 +2761,7 @@ Content-Length: 280
 <div class="paragraph">
 <p>일기를 생성합니다.</p>
 </div>
-<h4 id="_요청_26" class="discrete">요청</h4>
+<h4 id="_요청_28" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">POST /api/v1/diaries HTTP/1.1
@@ -2669,7 +2771,7 @@ Content-Length: 148
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 
 {
-  &quot;date&quot; : &quot;2023-12-14&quot;,
+  &quot;date&quot; : &quot;2024-01-10&quot;,
   &quot;dogName&quot; : &quot;사랑이&quot;,
   &quot;title&quot; : &quot;일기 제목&quot;,
   &quot;content&quot; : &quot;일기 내용&quot;,
@@ -2732,7 +2834,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_26" class="discrete">응답</h4>
+<h4 id="_응답_28" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 201 Created
@@ -2757,7 +2859,7 @@ Content-Length: 81
 <div class="paragraph">
 <p>일기 날짜, 제목, 내용, 이미지를 수정합니다.</p>
 </div>
-<h4 id="_요청_27" class="discrete">요청</h4>
+<h4 id="_요청_29" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">PUT /api/v1/diaries/1 HTTP/1.1
@@ -2767,7 +2869,7 @@ Content-Length: 148
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 
 {
-  &quot;date&quot; : &quot;2023-12-14&quot;,
+  &quot;date&quot; : &quot;2024-01-10&quot;,
   &quot;dogName&quot; : &quot;사랑이&quot;,
   &quot;title&quot; : &quot;일기 제목&quot;,
   &quot;content&quot; : &quot;일기 내용&quot;,
@@ -2849,7 +2951,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_27" class="discrete">응답</h4>
+<h4 id="_응답_29" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2872,7 +2974,7 @@ Content-Length: 62
 <div class="paragraph">
 <p>일기 id를 통해 일기를 삭제합니다.</p>
 </div>
-<h4 id="_요청_28" class="discrete">요청</h4>
+<h4 id="_요청_30" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">DELETE /api/v1/diaries/1 HTTP/1.1
@@ -2899,7 +3001,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_28" class="discrete">응답</h4>
+<h4 id="_응답_30" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2922,7 +3024,7 @@ Content-Length: 62
 <div class="paragraph">
 <p>일기 id를 통해 일기 공유용 UUID를 조회합니다.</p>
 </div>
-<h4 id="_요청_29" class="discrete">요청</h4>
+<h4 id="_요청_31" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries/1/share-uuid HTTP/1.1
@@ -2949,7 +3051,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_29" class="discrete">응답</h4>
+<h4 id="_응답_31" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -2963,7 +3065,7 @@ Content-Length: 115
   &quot;code&quot; : &quot;0000&quot;,
   &quot;message&quot; : &quot;정상&quot;,
   &quot;data&quot; : {
-    &quot;uuid&quot; : &quot;ecc6dd3d-6097-4981-83b9-24e0bab822dc&quot;
+    &quot;uuid&quot; : &quot;748ad087-fcc1-473b-b00e-b760d8d51770&quot;
   }
 }</code></pre>
 </div>
@@ -2974,7 +3076,7 @@ Content-Length: 115
 <div class="paragraph">
 <p>일기 UUID를 통해 일기를 조회합니다. 인증 헤더가 필요하지 않습니다.</p>
 </div>
-<h4 id="_요청_30" class="discrete">요청</h4>
+<h4 id="_요청_32" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/diaries/shared/1 HTTP/1.1
@@ -3000,7 +3102,7 @@ Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </tr>
 </tbody>
 </table>
-<h4 id="_응답_30" class="discrete">응답</h4>
+<h4 id="_응답_32" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -3015,9 +3117,9 @@ Content-Length: 281
   &quot;message&quot; : &quot;정상&quot;,
   &quot;data&quot; : {
     &quot;id&quot; : 1,
-    &quot;date&quot; : &quot;2023-12-13&quot;,
+    &quot;date&quot; : &quot;2024-01-09&quot;,
     &quot;dogName&quot; : &quot;코코&quot;,
-    &quot;createdAt&quot; : &quot;2023-12-14T15:53:38.655557&quot;,
+    &quot;createdAt&quot; : &quot;2024-01-10T14:56:03.775962&quot;,
     &quot;imageIds&quot; : [ 1, 2, 3, 4, 5 ],
     &quot;title&quot; : &quot;일기 1 제목&quot;,
     &quot;content&quot; : &quot;일기 1 내용&quot;
@@ -3039,14 +3141,14 @@ Content-Length: 281
 <div class="paragraph">
 <p>전체 공지를 조회합니다. 최신순으로 정렬됩니다. 별도의 인증이 필요 없습니다.</p>
 </div>
-<h4 id="_요청_31" class="discrete">요청</h4>
+<h4 id="_요청_33" class="discrete">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">GET /api/v1/notices HTTP/1.1
 Host: port-0-meommu-api-jvvy2blm5wku9j.sel5.cloudtype.app</code></pre>
 </div>
 </div>
-<h4 id="_응답_31" class="discrete">응답</h4>
+<h4 id="_응답_33" class="discrete">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight nowrap"><code data-lang="http">HTTP/1.1 200 OK
@@ -3064,12 +3166,12 @@ Content-Length: 374
       &quot;id&quot; : 2,
       &quot;title&quot; : &quot;공지 2 제목&quot;,
       &quot;content&quot; : &quot;공지 2 내용&quot;,
-      &quot;createdAt&quot; : &quot;2023-12-14T15:53:39.716026&quot;
+      &quot;createdAt&quot; : &quot;2024-01-10T14:56:05.290772&quot;
     }, {
       &quot;id&quot; : 1,
       &quot;title&quot; : &quot;공지 1 제목&quot;,
       &quot;content&quot; : &quot;공지 1 내용&quot;,
-      &quot;createdAt&quot; : &quot;2023-12-13T15:53:39.716012&quot;
+      &quot;createdAt&quot; : &quot;2024-01-09T14:56:05.290754&quot;
     } ]
   }
 }</code></pre>
@@ -3082,7 +3184,7 @@ Content-Length: 374
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-12-14 15:30:03 +0900
+Last updated 2023-12-14 15:58:52 +0900
 </div>
 </div>
 </body>

--- a/src/test/java/com/meommu/meommuapi/core/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/meommu/meommuapi/core/auth/controller/AuthControllerTest.java
@@ -1,9 +1,11 @@
 package com.meommu.meommuapi.core.auth.controller;
 
+import static com.meommu.meommuapi.util.documentation.DocumentConstant.*;
 import static com.meommu.meommuapi.util.documentation.DocumentFormatGenerator.*;
 import static com.meommu.meommuapi.util.documentation.DocumentUtils.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -15,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.meommu.meommuapi.core.auth.dto.ReissueRequest;
 import com.meommu.meommuapi.core.auth.dto.SignInRequest;
 import com.meommu.meommuapi.core.auth.dto.TokenResponse;
 import com.meommu.meommuapi.global.util.JsonUtils;
@@ -25,7 +28,7 @@ class AuthControllerTest extends ControllerTest {
 
 	@DisplayName("로그인: 성공 -> 201")
 	@Test
-	void testSignIn() throws Exception {
+	void signIn() throws Exception {
 		// given
 		var signInRequest = SignInRequest.builder()
 			.email("meommu@exam.com")
@@ -33,6 +36,7 @@ class AuthControllerTest extends ControllerTest {
 			.build();
 		var tokenResponse = TokenResponse.builder()
 			.accessToken("<ACCESS_TOKEN>")
+			.refreshToken("<REFRESH_TOKEN>")
 			.build();
 		given(authService.signIn(any())).willReturn(tokenResponse);
 
@@ -47,7 +51,8 @@ class AuthControllerTest extends ControllerTest {
 			status().isCreated(),
 			jsonPath("$.code").value("0000"),
 			jsonPath("$.message").value("정상"),
-			jsonPath("$.data.accessToken").value("<ACCESS_TOKEN>")
+			jsonPath("$.data.accessToken").value("<ACCESS_TOKEN>"),
+			jsonPath("$.data.refreshToken").value("<REFRESH_TOKEN>")
 		).andDo(
 			document("kindergartens/signIn/success",
 				getDocumentRequest(), getDocumentResponse(),
@@ -59,6 +64,68 @@ class AuthControllerTest extends ControllerTest {
 						.attributes(
 							getConstraints("constraints", "8~20자 사이여야 합니다. 숫자와 특수기호가 각각 한 글자 이상 포함되어야 합니다."))
 				)
+			)
+		);
+	}
+
+	@DisplayName("재발급: 성공 -> 201")
+	@Test
+	void reissue() throws Exception {
+		// given
+		var request = ReissueRequest.builder()
+			.refreshToken("<REFRESH_TOKEN>")
+			.build();
+		var response = TokenResponse.builder()
+			.accessToken("<ACCESS_TOKEN>")
+			.refreshToken("<REFRESH_TOKEN>")
+			.build();
+		given(authService.reissue(any(), any())).willReturn(response);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/v1/kindergartens/reissue")
+			.header(AUTHORIZATION, ACCESS_TOKEN_WITH_BEARER)
+			.content(JsonUtils.toJson(request))
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpectAll(
+			status().isCreated(),
+			jsonPath("$.code").value("0000"),
+			jsonPath("$.message").value("정상"),
+			jsonPath("$.data.accessToken").value("<ACCESS_TOKEN>"),
+			jsonPath("$.data.refreshToken").value("<REFRESH_TOKEN>")
+		).andDo(
+			document("kindergartens/reissue/success",
+				getDocumentRequest(), getDocumentResponse(),
+				requestFields(
+					fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("refresh token")
+				)
+			)
+		);
+	}
+
+	@DisplayName("로그아웃: 성공 -> 200")
+	@Test
+	void signOut() throws Exception {
+		// given
+		doNothing().when(authService).signOut(any());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/kindergartens/signout")
+			.header(AUTHORIZATION, ACCESS_TOKEN_WITH_BEARER)
+			.contentType(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpectAll(
+			status().isOk(),
+			jsonPath("$.code").value("0000"),
+			jsonPath("$.message").value("정상"),
+			jsonPath("$.data").doesNotExist()
+		).andDo(
+			document("kindergartens/signOut/success",
+				getDocumentRequest(), getDocumentResponse()
 			)
 		);
 	}

--- a/src/test/java/com/meommu/meommuapi/core/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/meommu/meommuapi/core/auth/service/AuthServiceTest.java
@@ -6,10 +6,13 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.meommu.meommuapi.core.auth.dto.AuthInfo;
+import com.meommu.meommuapi.core.auth.dto.ReissueRequest;
 import com.meommu.meommuapi.core.auth.dto.SignInRequest;
 import com.meommu.meommuapi.core.auth.dto.TokenResponse;
 import com.meommu.meommuapi.core.auth.exception.SignInFailedException;
@@ -22,6 +25,8 @@ class AuthServiceTest extends ServiceTest {
 
 	Kindergarten kindergarten;
 
+	AuthInfo authInfo;
+
 	@BeforeEach
 	void setUp() {
 		kindergarten = Kindergarten.builder()
@@ -31,9 +36,11 @@ class AuthServiceTest extends ServiceTest {
 			.email("meommu@exam.com")
 			.password(Password.of(encryptor, "Password1!"))
 			.build();
+
+		authInfo = new AuthInfo(1L);
 	}
 
-	@DisplayName("로그인을 하면 access token을 생성한다.")
+	@DisplayName("로그인을 하면 access token과 refresh token을 생성한다.")
 	@Test
 	void signIn() {
 		// given
@@ -44,12 +51,16 @@ class AuthServiceTest extends ServiceTest {
 		given(kindergartenRepository.findByEmailValueAndPasswordValue(any(), any())).willReturn(
 			Optional.ofNullable(kindergarten));
 		given(jwtTokenProvider.createAccessToken(any())).willReturn("AccessToken");
+		given(jwtTokenProvider.createRefreshToken(any())).willReturn("RefreshToken");
 
 		// when
 		TokenResponse tokenResponse = authService.signIn(request);
 
 		// then
-		assertThat(tokenResponse.getAccessToken()).isEqualTo("AccessToken");
+		Assertions.assertAll(
+			() -> assertThat(tokenResponse.getAccessToken()).isEqualTo("AccessToken"),
+			() -> assertThat(tokenResponse.getRefreshToken()).isEqualTo("RefreshToken")
+		);
 	}
 
 	@DisplayName("잘못된 이메일이나 비밀번호로 로그인을 하면 실패한다.")
@@ -65,5 +76,35 @@ class AuthServiceTest extends ServiceTest {
 		assertThatThrownBy(() -> authService.signIn(request))
 			.isInstanceOf(SignInFailedException.class)
 			.hasMessageContaining(AuthErrorCode.SIGN_IN_FAILED.getDescription());
+	}
+
+	@DisplayName("토큰 재발급을 하면 access token과 refresh token을 재생성한다.")
+	@Test
+	void reissue() {
+		// given
+		var request = ReissueRequest.builder()
+			.refreshToken("RefreshToken")
+			.build();
+		given(redisUtils.getRefreshToken(any())).willReturn("RefreshToken");
+		given(jwtTokenProvider.createAccessToken(any())).willReturn("NewAccessToken");
+		given(jwtTokenProvider.createRefreshToken(any())).willReturn("NewRefreshToken");
+		given(jwtTokenProvider.getExpiration(any())).willReturn(999999999L);
+
+		// when
+		TokenResponse tokenResponse = authService.reissue(authInfo, request);
+
+		// then
+		Assertions.assertAll(
+			() -> assertThat(tokenResponse.getAccessToken()).isEqualTo("NewAccessToken"),
+			() -> assertThat(tokenResponse.getRefreshToken()).isEqualTo("NewRefreshToken")
+		);
+	}
+
+	@DisplayName("로그아웃이 정상적으로 수행된다.")
+	@Test
+	void signOut() {
+		// when & then
+		assertThatNoException()
+			.isThrownBy(() -> authService.signOut(authInfo));
 	}
 }

--- a/src/test/java/com/meommu/meommuapi/util/ServiceTest.java
+++ b/src/test/java/com/meommu/meommuapi/util/ServiceTest.java
@@ -13,6 +13,7 @@ import com.meommu.meommuapi.core.diary.service.DiaryService;
 import com.meommu.meommuapi.core.kindergarten.domain.embedded.Encryptor;
 import com.meommu.meommuapi.core.kindergarten.repository.KindergartenRepository;
 import com.meommu.meommuapi.core.kindergarten.service.KindergartenService;
+import com.meommu.meommuapi.global.infra.redis.util.RedisUtils;
 
 @ExtendWith(MockitoExtension.class)
 public abstract class ServiceTest {
@@ -40,5 +41,8 @@ public abstract class ServiceTest {
 
 	@Mock
 	protected JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	protected RedisUtils redisUtils;
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,12 +17,19 @@ spring:
           timeout: 5000
           writetimeout: 5000
     auth-code-expiration-millis: 1800000
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+
 security:
   jwt:
     token:
       secret-key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno
       expire-length:
         access: 3600000
+        refresh: 3600000
 
 cloud:
   aws:


### PR DESCRIPTION
### 💁‍♂️ PR 개요
- #53 에 명시된 기능 구현했습니다.
- Redis 도입
- 로그아웃, 토큰 재발급 API 구현
<br/>   

### 📝 변경 사항
- **POST** `/api/v1/kindergartens/reissue` 토큰 재발급을 진행합니다. Header의 accessToken과 Body의 RefreshToken를 이용해 두 토큰을 재발급합니다.
- **DELETE** `/api/v1/kindergartens/signout` 로그아웃을 진행합니다. redis에 저장된 refreshToken을 제거합니다.
<br/>

### 📷 스크린 샷 (선택)
- 
<br/>

### 🗣 리뷰어한테 할 말 (선택)
- 
<br/>

### 🧪 테스트 범위 (선택)
- 컨트롤러, 서비스 테스트 작성했습니다.
<br/> 
